### PR TITLE
Fix malformed Gaussian process regression notebooks

### DIFF
--- a/src/gaussian_process_regression/gp_regression_a.ipynb
+++ b/src/gaussian_process_regression/gp_regression_a.ipynb
@@ -1,3 +1,41 @@
-    "with open(models_path + \"gp_model_a.pkl\" , \"wb\") as f:\n",
-    "model = pickle.load(open(models_path + 'gp_model_a.pkl', \"rb\"))\n",
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Gaussian Process Regression A\\n",
+        "Load the serialized GP model for inference.\\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import pickle\\n",
+        "from pathlib import Path\\n",
+        "\\n",
+        "models_path = Path('models')\\n",
+        "with open(models_path / 'gp_model_a.pkl', 'rb') as f:\\n",
+        "    model = pickle.load(f)\\n",
+        "\\n",
+        "model\\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/src/gaussian_process_regression/gp_regression_b.ipynb
+++ b/src/gaussian_process_regression/gp_regression_b.ipynb
@@ -1,3 +1,41 @@
-    "with open(models_path + \"gp_model_b.pkl\" , \"wb\") as f:\n",
-    "model = pickle.load(open(models_path + 'gp_model_b.pkl', \"rb\"))\n",
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Gaussian Process Regression B\\n",
+        "Load the serialized GP model for inference.\\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import pickle\\n",
+        "from pathlib import Path\\n",
+        "\\n",
+        "models_path = Path('models')\\n",
+        "with open(models_path / 'gp_model_b.pkl', 'rb') as f:\\n",
+        "    model = pickle.load(f)\\n",
+        "\\n",
+        "model\\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
### Motivation

- GitHub was unable to render the GP regression notebooks because the files were not valid JSON documents, preventing notebook viewing for `src/gaussian_process_regression/gp_regression_a.ipynb` and `src/gaussian_process_regression/gp_regression_b.ipynb`.

### Description

- Replaced the malformed contents of `gp_regression_a.ipynb` and `gp_regression_b.ipynb` with valid Jupyter notebook JSON documents (`nbformat` 4, `nbformat_minor` 5) so they parse as notebooks.
- Added a short markdown cell and a simple code cell in each notebook that loads the corresponding serialized model from the local `models` directory (`gp_model_a.pkl` / `gp_model_b.pkl`).
- Files now contain proper `cells`, `metadata.kernelspec`, and `language_info` fields expected by notebook viewers.

### Testing

- Verified both files are valid JSON by running `json.loads` on `src/gaussian_process_regression/gp_regression_a.ipynb` and `src/gaussian_process_regression/gp_regression_b.ipynb`, and both parsed successfully.
- Attempted `nbformat` schema validation with `nbformat.validate`, but `nbformat` is not installed in the environment so full schema validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f830e73fc8328aa789caea5f9a482)